### PR TITLE
Specify the path of jupyter-lab in the virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ jupyter labextension install @pyviz/jupyterlab_pyviz @jupyter-widgets/jupyterlab
 # Start the server and a browser window will automatically open and you'll be navigated to
 # the JupyterLab web page. Note that if you close the command prompt or Ctrl+C the process
 # at any point, the notebook server and all Python kernels created to run the notebooks will be terminated.
-jupyter-lab
+./venv/bin/jupyter-lab
 ```
 
 Now open any of the provided tutorial notebooks and start experimenting with the bot code.


### PR DESCRIPTION
It happens to me that simply running 'jupyterlab' pointed to the jupyterlab in the root directory in local machine and had access to packages installed in the virtual environment. Specifying the jupyterlab path by running './venv/bin/jupyter-lab' can avoid this problem.